### PR TITLE
Add floating action button for note creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# ChessAI
+# ChessAI Notes UI
+
+A simple notes interface with a sidebar containing **Quick Notes** and **Cahier de notes** sections. Each menu can expand or collapse to show notes and opens automatically with a small animation. The settings button in the top-right offers toggle switches for light/dark theme and automatic menu expansion on load.
+
+Open `index.html` in a browser to try it out.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 A simple notes interface with a sidebar containing **Quick Notes** and **Cahier de notes** sections. Each menu can expand or collapse to show notes and opens automatically with a small animation. The settings button in the top-right offers toggle switches for light/dark theme and automatic menu expansion on load.
 
+Use the floating **+** button to open a creation window with tabs for **Quick Note** and **Book Note**. The Quick Note tab lets you enter a name, pick a background color with a color wheel and create the note. Created notes open in a simple editor with back and save controls and appear under the *Quick Notes* menu.
+
 Open `index.html` in a browser to try it out.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Notes App</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="light">
+    <div class="app">
+        <aside class="sidebar">
+            <div class="menu-section">
+                <button class="menu-toggle">
+                    <span>Quick Notes</span>
+                    <span class="arrow">▼</span>
+                </button>
+                <ul class="menu-content"></ul>
+            </div>
+            <div class="menu-section">
+                <button class="menu-toggle">
+                    <span>Cahier de notes</span>
+                    <span class="arrow">▼</span>
+                </button>
+                <ul class="menu-content"></ul>
+            </div>
+        </aside>
+        <main>
+            <h2>Welcome</h2>
+            <p>Select or create a note...</p>
+        </main>
+    </div>
+    <div class="settings">
+        <button id="settings-button">⚙️</button>
+        <div id="settings-menu" class="hidden">
+            <div class="setting">
+                <span>Dark Mode</span>
+                <label class="switch">
+                    <input type="checkbox" id="theme-switch">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="setting">
+                <span>Auto-expand menus</span>
+                <label class="switch">
+                    <input type="checkbox" id="auto-expand-switch">
+                    <span class="slider"></span>
+                </label>
+            </div>
+        </div>
+    </div>
+    <button id="add-note-button" class="fab">+</button>
+    <div id="note-modal" class="modal hidden">
+        <div class="modal-content">
+            <h3>New note</h3>
+            <button class="modal-option" data-type="quick">Quick Note</button>
+            <button class="modal-option" data-type="notebook">Notebook</button>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,14 +14,14 @@
                     <span>Quick Notes</span>
                     <span class="arrow">▼</span>
                 </button>
-                <ul class="menu-content"></ul>
+                <ul class="menu-content" id="quick-notes-list"></ul>
             </div>
             <div class="menu-section">
                 <button class="menu-toggle">
                     <span>Cahier de notes</span>
                     <span class="arrow">▼</span>
                 </button>
-                <ul class="menu-content"></ul>
+                <ul class="menu-content" id="notebook-list"></ul>
             </div>
         </aside>
         <main>
@@ -50,11 +50,31 @@
     </div>
     <button id="add-note-button" class="fab">+</button>
     <div id="note-modal" class="modal hidden">
-        <div class="modal-content">
-            <h3>New note</h3>
-            <button class="modal-option" data-type="quick">Quick Note</button>
-            <button class="modal-option" data-type="notebook">Notebook</button>
+        <div class="modal-content new-note">
+            <div class="tabs">
+                <button class="tab active" data-tab="quick">Quick Note</button>
+                <button class="tab" data-tab="notebook">Book Note</button>
+            </div>
+            <div class="tab-content" id="quick-tab">
+                <input type="text" id="note-title" placeholder="Note name">
+                <div class="color-picker-wrapper">
+                    <div id="color-display"></div>
+                    <input type="color" id="note-color" value="#ffffff" class="hidden">
+                </div>
+                <button id="create-note">Create</button>
+            </div>
+            <div class="tab-content hidden" id="notebook-tab">
+                <p>Notebook options coming soon...</p>
+            </div>
         </div>
+    </div>
+    <div id="editor" class="editor hidden">
+        <div class="editor-bar">
+            <button id="back-button" class="icon-button">←</button>
+            <span id="editor-title"></span>
+            <button id="save-button" class="icon-button">💾</button>
+        </div>
+        <textarea id="editor-content"></textarea>
     </div>
     <script src="script.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "chessai-notes-ui",
+  "version": "1.0.0",
+  "description": "Simple notes UI with sidebar and theme toggle",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,70 @@
+// Settings menu toggle
+const settingsButton = document.getElementById('settings-button');
+const settingsMenu = document.getElementById('settings-menu');
+settingsButton.addEventListener('click', () => {
+    settingsMenu.classList.toggle('hidden');
+});
+
+// Menu sections
+const menuSections = document.querySelectorAll('.menu-section');
+menuSections.forEach(section => {
+    const toggle = section.querySelector('.menu-toggle');
+    toggle.addEventListener('click', () => section.classList.toggle('open'));
+});
+
+// Theme and auto-expand switches
+const themeSwitch = document.getElementById('theme-switch');
+const autoExpandSwitch = document.getElementById('auto-expand-switch');
+const body = document.body;
+
+function loadTheme() {
+    const theme = localStorage.getItem('theme') || 'light';
+    body.classList.remove('light', 'dark');
+    body.classList.add(theme);
+    themeSwitch.checked = theme === 'dark';
+}
+
+function loadAutoExpand() {
+    const pref = localStorage.getItem('autoExpand');
+    const shouldExpand = pref !== 'false';
+    autoExpandSwitch.checked = shouldExpand;
+    if (shouldExpand) {
+        setTimeout(() => menuSections.forEach(s => s.classList.add('open')), 100);
+    }
+}
+
+themeSwitch.addEventListener('change', () => {
+    const theme = themeSwitch.checked ? 'dark' : 'light';
+    body.classList.remove('light', 'dark');
+    body.classList.add(theme);
+    localStorage.setItem('theme', theme);
+});
+
+autoExpandSwitch.addEventListener('change', () => {
+    localStorage.setItem('autoExpand', autoExpandSwitch.checked);
+});
+
+loadTheme();
+loadAutoExpand();
+
+// Add note modal
+const addNoteButton = document.getElementById('add-note-button');
+const noteModal = document.getElementById('note-modal');
+const modalOptions = noteModal.querySelectorAll('.modal-option');
+
+addNoteButton.addEventListener('click', () => {
+    noteModal.classList.remove('hidden');
+});
+
+noteModal.addEventListener('click', (e) => {
+    if (e.target === noteModal) {
+        noteModal.classList.add('hidden');
+    }
+});
+
+modalOptions.forEach(btn => {
+    btn.addEventListener('click', () => {
+        // Placeholder for creating the selected note type
+        noteModal.classList.add('hidden');
+    });
+});

--- a/script.js
+++ b/script.js
@@ -47,24 +47,92 @@ autoExpandSwitch.addEventListener('change', () => {
 loadTheme();
 loadAutoExpand();
 
-// Add note modal
+// Note management
+let notes = [];
+let currentNote = null;
+const quickNotesList = document.getElementById('quick-notes-list');
+
+function renderNotes() {
+    quickNotesList.innerHTML = '';
+    notes.forEach(note => {
+        const li = document.createElement('li');
+        li.textContent = note.title;
+        li.style.background = note.color;
+        li.addEventListener('click', () => openEditor(note));
+        quickNotesList.appendChild(li);
+    });
+}
+
+// Add note modal with tabs
 const addNoteButton = document.getElementById('add-note-button');
 const noteModal = document.getElementById('note-modal');
-const modalOptions = noteModal.querySelectorAll('.modal-option');
+const tabs = noteModal.querySelectorAll('.tab');
+const tabContents = noteModal.querySelectorAll('.tab-content');
+const noteTitleInput = document.getElementById('note-title');
+const colorDisplay = document.getElementById('color-display');
+const noteColorInput = document.getElementById('note-color');
+const createNoteBtn = document.getElementById('create-note');
 
 addNoteButton.addEventListener('click', () => {
     noteModal.classList.remove('hidden');
 });
 
-noteModal.addEventListener('click', (e) => {
+noteModal.addEventListener('click', e => {
     if (e.target === noteModal) {
         noteModal.classList.add('hidden');
     }
 });
 
-modalOptions.forEach(btn => {
-    btn.addEventListener('click', () => {
-        // Placeholder for creating the selected note type
-        noteModal.classList.add('hidden');
+tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+        tabs.forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        tabContents.forEach(c => c.classList.add('hidden'));
+        document.getElementById(tab.dataset.tab + '-tab').classList.remove('hidden');
     });
+});
+
+colorDisplay.addEventListener('click', () => noteColorInput.click());
+noteColorInput.addEventListener('input', () => {
+    colorDisplay.style.background = noteColorInput.value;
+});
+
+createNoteBtn.addEventListener('click', () => {
+    const title = noteTitleInput.value.trim() || 'Untitled';
+    const color = noteColorInput.value;
+    const note = { id: Date.now(), title, color, content: '' };
+    notes.push(note);
+    renderNotes();
+    noteModal.classList.add('hidden');
+    openEditor(note);
+    noteTitleInput.value = '';
+    noteColorInput.value = '#ffffff';
+    colorDisplay.style.background = '#ffffff';
+});
+
+// Editor
+const editor = document.getElementById('editor');
+const editorTitle = document.getElementById('editor-title');
+const editorContent = document.getElementById('editor-content');
+const backButton = document.getElementById('back-button');
+const saveButton = document.getElementById('save-button');
+
+function openEditor(note) {
+    currentNote = note;
+    editorTitle.textContent = note.title;
+    editorContent.value = note.content;
+    editor.classList.remove('hidden');
+}
+
+backButton.addEventListener('click', () => {
+    editor.classList.add('hidden');
+    currentNote = null;
+});
+
+saveButton.addEventListener('click', () => {
+    if (currentNote) {
+        currentNote.content = editorContent.value;
+    }
+    editor.classList.add('hidden');
+    currentNote = null;
 });

--- a/styles.css
+++ b/styles.css
@@ -180,7 +180,69 @@ main {
     gap: 0.5rem;
 }
 
-.modal-option {
+input:checked + .slider {
+    background: var(--accent);
+}
+
+input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+/* New note modal styles */
+.modal-content.new-note {
+    width: 400px;
+    max-width: 90%;
+}
+
+.tabs {
+    display: flex;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+    margin-bottom: 1rem;
+}
+
+.tab {
+    flex: 1;
+    background: none;
+    border: none;
+    padding: 0.5rem;
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.tab.active {
+    border-bottom: 2px solid var(--accent);
+    font-weight: bold;
+}
+
+.tab-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+#note-title {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.color-picker-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+#color-display {
+    width: 24px;
+    height: 24px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    background: #fff;
+}
+
+#create-note {
+    align-self: flex-end;
     background: var(--accent);
     color: #fff;
     border: none;
@@ -189,10 +251,42 @@ main {
     cursor: pointer;
 }
 
-input:checked + .slider {
-    background: var(--accent);
+/* Editor */
+.editor {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--sidebar-bg);
+    display: flex;
+    flex-direction: column;
 }
 
-input:checked + .slider:before {
-    transform: translateX(20px);
+.editor-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 1rem;
+    background: var(--accent);
+    color: #fff;
+}
+
+.icon-button {
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
+#editor-content {
+    flex: 1;
+    padding: 1rem;
+    border: none;
+    outline: none;
+    background: inherit;
+    color: inherit;
+    font-family: inherit;
+    resize: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,198 @@
+:root {
+    --accent: #007bff;
+}
+body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    transition: background 0.3s, color 0.3s;
+}
+body.light {
+    --sidebar-bg: #ffffff;
+    background: #f5f5f5;
+    color: #222;
+}
+body.dark {
+    --sidebar-bg: #1e1e1e;
+    --accent: #66b2ff;
+    background: #222;
+    color: #f5f5f5;
+}
+
+.hidden {
+    display: none;
+}
+
+.app {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 250px;
+    background: var(--sidebar-bg);
+    border-right: 1px solid rgba(0,0,0,0.1);
+}
+
+.menu-toggle {
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 0.75rem 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 1rem;
+    cursor: pointer;
+    color: inherit;
+}
+
+.arrow {
+    transition: transform 0.2s ease;
+}
+
+.menu-content {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 1.5rem;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease;
+}
+
+.menu-section.open .menu-content {
+    max-height: 500px;
+}
+
+.menu-section.open .arrow {
+    transform: rotate(-180deg);
+}
+
+main {
+    flex: 1;
+    padding: 1rem;
+}
+
+.settings {
+    position: fixed;
+    top: 0.5rem;
+    right: 0.5rem;
+}
+
+#settings-button {
+    background: none;
+    border: none;
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
+#settings-menu {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    background: var(--sidebar-bg);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    margin-top: 0.5rem;
+}
+
+#settings-menu.hidden {
+    display: none;
+}
+
+.setting {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 20px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #ccc;
+    transition: 0.2s;
+    border-radius: 20px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    top: 2px;
+    background: #fff;
+    transition: 0.2s;
+    border-radius: 50%;
+}
+
+.fab {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    font-size: 2rem;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal-content {
+    background: var(--sidebar-bg);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.modal-option {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+}
+
+input:checked + .slider {
+    background: var(--accent);
+}
+
+input:checked + .slider:before {
+    transform: translateX(20px);
+}


### PR DESCRIPTION
## Summary
- add floating "+" button that opens modal to choose quick note or notebook
- style modal and button with modern look
- wire up JS to open/close modal and handle options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c51c9800832aaf29510f671aea27